### PR TITLE
docs(README): correct gasyoun contributor count 36→39

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ pie showData
 | Contributor | Commits |
 |---|---|
 | drdhaval2785 | 66 |
+| gasyoun (Mārcis Gasūns) | 39 |
 | funderburkjim | 35 |
-| gasyoun (Mārcis Gasūns) | 36 |
 
 ## Source
 


### PR DESCRIPTION
Live GitHub contributors API reports 39, not 36 (README drifted since the H548 reconciliation merged). One-line fix, no other changes.

Ref: H548 follow-up.