### PR TITLE
docs(changelog): minimal KaC for VCP (H2012 Phase F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to **VCP** are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-07-31
+
+### Added
+- **Initial changelog** (H2012 Phase F residual, Grok 4.5 `grok-4.5`): records current
+  repository state after 152 commits since first recorded commit (2014-01-21). Historical
+  detail was not reconstructed commit-by-commit; see `git log` for the full trail.


### PR DESCRIPTION
H2012 Phase F residual — Tier 4 minimal changelog. Grok 4.5 (`grok-4.5`).